### PR TITLE
Add way to configure the batch count/size balance for the bot

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,19 @@
+name: golangci-lint
+on:
+  pull_request:
+permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest

--- a/databases/sqlite/sqlite.go
+++ b/databases/sqlite/sqlite.go
@@ -73,6 +73,15 @@ width INTEGER NOT NULL,
 height INTEGER NOT NULL
 );`
 
+const addSettingsBatchColumnsQuery string = `
+ALTER TABLE default_settings ADD COLUMN batch_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE default_settings ADD COLUMN batch_size INTEGER NOT NULL DEFAULT 0;
+`
+
+const addGenerationBatchSizeColumnQuery string = `
+ALTER TABLE image_generations ADD COLUMN batch_count INTEGER NOT NULL DEFAULT 0;
+`
+
 type migration struct {
 	migrationName  string
 	migrationQuery string
@@ -86,6 +95,8 @@ var migrations = []migration{
 	{migrationName: "drop hires firstpass columns", migrationQuery: dropHiresFirstPassDimensionColumnsQuery},
 	{migrationName: "add hires resize columns", migrationQuery: addHiresResizeColumnsQuery},
 	{migrationName: "create default settings table", migrationQuery: createDefaultSettingsTableIfNotExistsQuery},
+	{migrationName: "add settings batch columns", migrationQuery: addSettingsBatchColumnsQuery},
+	{migrationName: "add generation batch count column", migrationQuery: addGenerationBatchSizeColumnQuery},
 }
 
 func New(ctx context.Context) (*sql.DB, error) {

--- a/discord_bot/discord_bot.go
+++ b/discord_bot/discord_bot.go
@@ -393,7 +393,7 @@ func (b *botImpl) processImagineCommand(s *discordgo.Session, i *discordgo.Inter
 		}
 	}
 
-	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+	err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
 			Content: fmt.Sprintf(
@@ -403,6 +403,9 @@ func (b *botImpl) processImagineCommand(s *discordgo.Session, i *discordgo.Inter
 				prompt),
 		},
 	})
+	if err != nil {
+		log.Printf("Error responding to interaction: %v", err)
+	}
 }
 
 func settingsMessageComponents(settings *entities.DefaultSettings) []discordgo.MessageComponent {
@@ -513,25 +516,31 @@ func (b *botImpl) processImagineDimensionSetting(s *discordgo.Session, i *discor
 	if err != nil {
 		log.Printf("error updating default dimensions: %v", err)
 
-		s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseUpdateMessage,
 			Data: &discordgo.InteractionResponseData{
 				Content: "Error updating default dimensions...",
 			},
 		})
+		if err != nil {
+			log.Printf("Error responding to interaction: %v", err)
+		}
 
 		return
 	}
 
 	messageComponents := settingsMessageComponents(botSettings)
 
-	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+	err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseUpdateMessage,
 		Data: &discordgo.InteractionResponseData{
 			Content:    "Choose defaults settings for the imagine command:",
 			Components: messageComponents,
 		},
 	})
+	if err != nil {
+		log.Printf("Error responding to interaction: %v", err)
+	}
 }
 
 func (b *botImpl) processImagineBatchSetting(s *discordgo.Session, i *discordgo.InteractionCreate, batchCount, batchSize int) {
@@ -539,23 +548,29 @@ func (b *botImpl) processImagineBatchSetting(s *discordgo.Session, i *discordgo.
 	if err != nil {
 		log.Printf("error updating batch settings: %v", err)
 
-		s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseUpdateMessage,
 			Data: &discordgo.InteractionResponseData{
 				Content: "Error updating batch settings...",
 			},
 		})
+		if err != nil {
+			log.Printf("Error responding to interaction: %v", err)
+		}
 
 		return
 	}
 
 	messageComponents := settingsMessageComponents(botSettings)
 
-	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+	err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseUpdateMessage,
 		Data: &discordgo.InteractionResponseData{
 			Content:    "Choose defaults settings for the imagine command:",
 			Components: messageComponents,
 		},
 	})
+	if err != nil {
+		log.Printf("Error responding to interaction: %v", err)
+	}
 }

--- a/discord_bot/discord_bot.go
+++ b/discord_bot/discord_bot.go
@@ -176,7 +176,7 @@ func New(cfg Config) (Bot, error) {
 					return
 				}
 
-				batchSizeInt := 1
+				var batchSizeInt int
 
 				// calculate the corresponding batch size
 				switch batchCountInt {
@@ -209,7 +209,7 @@ func New(cfg Config) (Bot, error) {
 					return
 				}
 
-				batchCountInt := 1
+				var batchCountInt int
 
 				// calculate the corresponding batch count
 				switch batchSizeInt {

--- a/discord_bot/discord_bot.go
+++ b/discord_bot/discord_bot.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"stable_diffusion_bot/entities"
 	"stable_diffusion_bot/imagine_queue"
 	"strconv"
 	"strings"
@@ -159,6 +160,72 @@ func New(cfg Config) (Bot, error) {
 				}
 
 				bot.processImagineDimensionSetting(s, i, widthInt, heightInt)
+			case customID == "imagine_batch_count_setting_menu":
+				if len(i.MessageComponentData().Values) == 0 {
+					log.Printf("No values for imagine batch count setting menu")
+
+					return
+				}
+
+				batchCount := i.MessageComponentData().Values[0]
+
+				batchCountInt, intErr := strconv.Atoi(batchCount)
+				if intErr != nil {
+					log.Printf("Error parsing batch count: %v", err)
+
+					return
+				}
+
+				batchSizeInt := 1
+
+				// calculate the corresponding batch size
+				switch batchCountInt {
+				case 1:
+					batchSizeInt = 4
+				case 2:
+					batchSizeInt = 2
+				case 4:
+					batchSizeInt = 1
+				default:
+					log.Printf("Unknown batch count: %v", batchCountInt)
+
+					return
+				}
+
+				bot.processImagineBatchSetting(s, i, batchCountInt, batchSizeInt)
+			case customID == "imagine_batch_size_setting_menu":
+				if len(i.MessageComponentData().Values) == 0 {
+					log.Printf("No values for imagine batch count setting menu")
+
+					return
+				}
+
+				batchSize := i.MessageComponentData().Values[0]
+
+				batchSizeInt, intErr := strconv.Atoi(batchSize)
+				if intErr != nil {
+					log.Printf("Error parsing batch count: %v", err)
+
+					return
+				}
+
+				batchCountInt := 1
+
+				// calculate the corresponding batch count
+				switch batchSizeInt {
+				case 1:
+					batchCountInt = 4
+				case 2:
+					batchCountInt = 2
+				case 4:
+					batchCountInt = 1
+				default:
+					log.Printf("Unknown batch size: %v", batchSizeInt)
+
+					return
+				}
+
+				bot.processImagineBatchSetting(s, i, batchCountInt, batchSizeInt)
 			default:
 				log.Printf("Unknown message component '%v'", i.MessageComponentData().CustomID)
 			}
@@ -338,47 +405,102 @@ func (b *botImpl) processImagineCommand(s *discordgo.Session, i *discordgo.Inter
 	})
 }
 
-func (b *botImpl) processImagineSettingsCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	defaultWidth, err := b.imagineQueue.GetDefaultBotWidth()
-	if err != nil {
-		log.Printf("error getting default width for settings command: %v", err)
-	}
-
-	defaultHeight, err := b.imagineQueue.GetDefaultBotHeight()
-	if err != nil {
-		log.Printf("error getting default height for settings command: %v", err)
-	}
-
+func settingsMessageComponents(settings *entities.DefaultSettings) []discordgo.MessageComponent {
 	minValues := 1
 
-	err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-		Type: discordgo.InteractionResponseChannelMessageWithSource,
-		Data: &discordgo.InteractionResponseData{
-			Title:   "Settings",
-			Content: "Choose defaults settings for the imagine command:",
+	return []discordgo.MessageComponent{
+		discordgo.ActionsRow{
 			Components: []discordgo.MessageComponent{
-				discordgo.ActionsRow{
-					Components: []discordgo.MessageComponent{
-						discordgo.SelectMenu{
-							CustomID:  "imagine_dimension_setting_menu",
-							MinValues: &minValues,
-							MaxValues: 1,
-							Options: []discordgo.SelectMenuOption{
-								{
-									Label:   "Size: 512x512",
-									Value:   "512_512",
-									Default: defaultWidth == 512 && defaultHeight == 512,
-								},
-								{
-									Label:   "Size: 768x768",
-									Value:   "768_768",
-									Default: defaultWidth == 768 && defaultHeight == 768,
-								},
-							},
+				discordgo.SelectMenu{
+					CustomID:  "imagine_dimension_setting_menu",
+					MinValues: &minValues,
+					MaxValues: 1,
+					Options: []discordgo.SelectMenuOption{
+						{
+							Label:   "Size: 512x512",
+							Value:   "512_512",
+							Default: settings.Width == 512 && settings.Height == 512,
+						},
+						{
+							Label:   "Size: 768x768",
+							Value:   "768_768",
+							Default: settings.Width == 768 && settings.Height == 768,
 						},
 					},
 				},
 			},
+		},
+		discordgo.ActionsRow{
+			Components: []discordgo.MessageComponent{
+				discordgo.SelectMenu{
+					CustomID:  "imagine_batch_count_setting_menu",
+					MinValues: &minValues,
+					MaxValues: 1,
+					Options: []discordgo.SelectMenuOption{
+						{
+							Label:   "Batch count: 1",
+							Value:   "1",
+							Default: settings.BatchCount == 1,
+						},
+						{
+							Label:   "Batch count: 2",
+							Value:   "2",
+							Default: settings.BatchCount == 2,
+						},
+						{
+							Label:   "Batch count: 4",
+							Value:   "4",
+							Default: settings.BatchCount == 4,
+						},
+					},
+				},
+			},
+		},
+		discordgo.ActionsRow{
+			Components: []discordgo.MessageComponent{
+				discordgo.SelectMenu{
+					CustomID:  "imagine_batch_size_setting_menu",
+					MinValues: &minValues,
+					MaxValues: 1,
+					Options: []discordgo.SelectMenuOption{
+						{
+							Label:   "Batch size: 1",
+							Value:   "1",
+							Default: settings.BatchSize == 1,
+						},
+						{
+							Label:   "Batch size: 2",
+							Value:   "2",
+							Default: settings.BatchSize == 2,
+						},
+						{
+							Label:   "Batch size: 4",
+							Value:   "4",
+							Default: settings.BatchSize == 4,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (b *botImpl) processImagineSettingsCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	botSettings, err := b.imagineQueue.GetBotDefaultSettings()
+	if err != nil {
+		log.Printf("error getting default settings for settings command: %v", err)
+
+		return
+	}
+
+	messageComponents := settingsMessageComponents(botSettings)
+
+	err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Title:      "Settings",
+			Content:    "Choose defaults settings for the imagine command:",
+			Components: messageComponents,
 		},
 	})
 	if err != nil {
@@ -387,7 +509,7 @@ func (b *botImpl) processImagineSettingsCommand(s *discordgo.Session, i *discord
 }
 
 func (b *botImpl) processImagineDimensionSetting(s *discordgo.Session, i *discordgo.InteractionCreate, height, width int) {
-	err := b.imagineQueue.UpdateDefaultDimensions(width, height)
+	botSettings, err := b.imagineQueue.UpdateDefaultDimensions(width, height)
 	if err != nil {
 		log.Printf("error updating default dimensions: %v", err)
 
@@ -401,35 +523,39 @@ func (b *botImpl) processImagineDimensionSetting(s *discordgo.Session, i *discor
 		return
 	}
 
-	minValues := 1
+	messageComponents := settingsMessageComponents(botSettings)
 
 	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseUpdateMessage,
 		Data: &discordgo.InteractionResponseData{
-			Content: "Choose defaults settings for the imagine command:",
-			Components: []discordgo.MessageComponent{
-				discordgo.ActionsRow{
-					Components: []discordgo.MessageComponent{
-						discordgo.SelectMenu{
-							CustomID:  "imagine_dimension_setting_menu",
-							MinValues: &minValues,
-							MaxValues: 1,
-							Options: []discordgo.SelectMenuOption{
-								{
-									Label:   "Size: 512x512",
-									Value:   "512_512",
-									Default: width == 512 && height == 512,
-								},
-								{
-									Label:   "Size: 768x768",
-									Value:   "768_768",
-									Default: width == 768 && height == 768,
-								},
-							},
-						},
-					},
-				},
+			Content:    "Choose defaults settings for the imagine command:",
+			Components: messageComponents,
+		},
+	})
+}
+
+func (b *botImpl) processImagineBatchSetting(s *discordgo.Session, i *discordgo.InteractionCreate, batchCount, batchSize int) {
+	botSettings, err := b.imagineQueue.UpdateDefaultBatch(batchCount, batchSize)
+	if err != nil {
+		log.Printf("error updating batch settings: %v", err)
+
+		s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseUpdateMessage,
+			Data: &discordgo.InteractionResponseData{
+				Content: "Error updating batch settings...",
 			},
+		})
+
+		return
+	}
+
+	messageComponents := settingsMessageComponents(botSettings)
+
+	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseUpdateMessage,
+		Data: &discordgo.InteractionResponseData{
+			Content:    "Choose defaults settings for the imagine command:",
+			Components: messageComponents,
 		},
 	})
 }

--- a/entities/default_settings.go
+++ b/entities/default_settings.go
@@ -1,7 +1,9 @@
 package entities
 
 type DefaultSettings struct {
-	MemberID string `json:"member_id"`
-	Width    int    `json:"width"`
-	Height   int    `json:"height"`
+	MemberID   string `json:"member_id"`
+	Width      int    `json:"width"`
+	Height     int    `json:"height"`
+	BatchCount int    `json:"batch_count"`
+	BatchSize  int    `json:"batch_size"`
 }

--- a/entities/image_generation.go
+++ b/entities/image_generation.go
@@ -17,6 +17,7 @@ type ImageGeneration struct {
 	HiresWidth        int       `json:"hires_width"`
 	HiresHeight       int       `json:"hires_height"`
 	DenoisingStrength float64   `json:"denoising_strength"`
+	BatchCount        int       `json:"batch_count"`
 	BatchSize         int       `json:"batch_size"`
 	Seed              int       `json:"seed"`
 	Subseed           int       `json:"subseed"`

--- a/imagine_queue/interface.go
+++ b/imagine_queue/interface.go
@@ -1,11 +1,15 @@
 package imagine_queue
 
-import "github.com/bwmarrin/discordgo"
+import (
+	"stable_diffusion_bot/entities"
+
+	"github.com/bwmarrin/discordgo"
+)
 
 type Queue interface {
 	AddImagine(item *QueueItem) (int, error)
 	StartPolling(botSession *discordgo.Session)
-	GetDefaultBotWidth() (int, error)
-	GetDefaultBotHeight() (int, error)
-	UpdateDefaultDimensions(width, height int) error
+	GetBotDefaultSettings() (*entities.DefaultSettings, error)
+	UpdateDefaultDimensions(width, height int) (*entities.DefaultSettings, error)
+	UpdateDefaultBatch(batchCount, batchSize int) (*entities.DefaultSettings, error)
 }

--- a/imagine_queue/queue.go
+++ b/imagine_queue/queue.go
@@ -27,8 +27,10 @@ import (
 const (
 	botID = "bot"
 
-	initializedWidth  = 512
-	initializedHeight = 512
+	initializedWidth      = 512
+	initializedHeight     = 512
+	initializedBatchCount = 4
+	initializedBatchSize  = 1
 )
 
 type queueImpl struct {
@@ -150,18 +152,47 @@ func (q *queueImpl) pullNextInQueue() {
 	}
 }
 
+func (q *queueImpl) fillInBotDefaults(settings *entities.DefaultSettings) (*entities.DefaultSettings, bool) {
+	updated := false
+
+	if settings == nil {
+		settings = &entities.DefaultSettings{
+			MemberID: botID,
+		}
+	}
+
+	if settings.Width == 0 {
+		settings.Width = initializedWidth
+		updated = true
+	}
+
+	if settings.Height == 0 {
+		settings.Height = initializedHeight
+		updated = true
+	}
+
+	if settings.BatchCount == 0 {
+		settings.BatchCount = initializedBatchCount
+		updated = true
+	}
+
+	if settings.BatchSize == 0 {
+		settings.BatchSize = initializedBatchSize
+		updated = true
+	}
+
+	return settings, updated
+}
+
 func (q *queueImpl) initializeOrGetBotDefaults() (*entities.DefaultSettings, error) {
-	botDefaultSettings, err := q.getBotDefaultSettings()
+	botDefaultSettings, err := q.GetBotDefaultSettings()
 	if err != nil && !errors.Is(err, &repositories.NotFoundError{}) {
 		return nil, err
 	}
 
-	if botDefaultSettings == nil {
-		botDefaultSettings, err = q.defaultSettingsRepo.Upsert(context.Background(), &entities.DefaultSettings{
-			MemberID: botID,
-			Width:    initializedWidth,
-			Height:   initializedHeight,
-		})
+	botDefaultSettings, updated := q.fillInBotDefaults(botDefaultSettings)
+	if updated {
+		botDefaultSettings, err = q.defaultSettingsRepo.Upsert(context.Background(), botDefaultSettings)
 		if err != nil {
 			return nil, err
 		}
@@ -174,7 +205,7 @@ func (q *queueImpl) initializeOrGetBotDefaults() (*entities.DefaultSettings, err
 	return botDefaultSettings, nil
 }
 
-func (q *queueImpl) getBotDefaultSettings() (*entities.DefaultSettings, error) {
+func (q *queueImpl) GetBotDefaultSettings() (*entities.DefaultSettings, error) {
 	if q.botDefaultSettings != nil {
 		return q.botDefaultSettings, nil
 	}
@@ -190,7 +221,7 @@ func (q *queueImpl) getBotDefaultSettings() (*entities.DefaultSettings, error) {
 }
 
 func (q *queueImpl) defaultWidth() (int, error) {
-	defaultSettings, err := q.getBotDefaultSettings()
+	defaultSettings, err := q.GetBotDefaultSettings()
 	if err != nil {
 		return 0, err
 	}
@@ -199,7 +230,7 @@ func (q *queueImpl) defaultWidth() (int, error) {
 }
 
 func (q *queueImpl) defaultHeight() (int, error) {
-	defaultSettings, err := q.getBotDefaultSettings()
+	defaultSettings, err := q.GetBotDefaultSettings()
 	if err != nil {
 		return 0, err
 	}
@@ -207,18 +238,28 @@ func (q *queueImpl) defaultHeight() (int, error) {
 	return defaultSettings.Height, nil
 }
 
-func (q *queueImpl) GetDefaultBotWidth() (int, error) {
-	return q.defaultWidth()
-}
-
-func (q *queueImpl) GetDefaultBotHeight() (int, error) {
-	return q.defaultHeight()
-}
-
-func (q *queueImpl) UpdateDefaultDimensions(width, height int) error {
-	defaultSettings, err := q.getBotDefaultSettings()
+func (q *queueImpl) defaultBatchCount() (int, error) {
+	defaultSettings, err := q.GetBotDefaultSettings()
 	if err != nil {
-		return err
+		return 0, err
+	}
+
+	return defaultSettings.BatchCount, nil
+}
+
+func (q *queueImpl) defaultBatchSize() (int, error) {
+	defaultSettings, err := q.GetBotDefaultSettings()
+	if err != nil {
+		return 0, err
+	}
+
+	return defaultSettings.BatchSize, nil
+}
+
+func (q *queueImpl) UpdateDefaultDimensions(width, height int) (*entities.DefaultSettings, error) {
+	defaultSettings, err := q.GetBotDefaultSettings()
+	if err != nil {
+		return nil, err
 	}
 
 	defaultSettings.Width = width
@@ -226,14 +267,35 @@ func (q *queueImpl) UpdateDefaultDimensions(width, height int) error {
 
 	newDefaultSettings, err := q.defaultSettingsRepo.Upsert(context.Background(), defaultSettings)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	q.botDefaultSettings = newDefaultSettings
 
 	log.Printf("Updated default dimensions to: %dx%d\n", width, height)
 
-	return nil
+	return newDefaultSettings, nil
+}
+
+func (q *queueImpl) UpdateDefaultBatch(batchCount, batchSize int) (*entities.DefaultSettings, error) {
+	defaultSettings, err := q.GetBotDefaultSettings()
+	if err != nil {
+		return nil, err
+	}
+
+	defaultSettings.BatchCount = batchCount
+	defaultSettings.BatchSize = batchSize
+
+	newDefaultSettings, err := q.defaultSettingsRepo.Upsert(context.Background(), defaultSettings)
+	if err != nil {
+		return nil, err
+	}
+
+	q.botDefaultSettings = newDefaultSettings
+
+	log.Printf("Updated default batch count/size to: %d/%d\n", batchCount, batchSize)
+
+	return newDefaultSettings, nil
 }
 
 type dimensionsResult struct {
@@ -355,7 +417,6 @@ func (q *queueImpl) processCurrentImagine() {
 			HiresWidth:        hiresWidth,
 			HiresHeight:       hiresHeight,
 			DenoisingStrength: 0.7,
-			BatchSize:         1,
 			Seed:              -1,
 			Subseed:           -1,
 			SubseedStrength:   0,
@@ -440,10 +501,27 @@ func (q *queueImpl) processImagineGrid(newGeneration *entities.ImageGeneration, 
 		log.Printf("Error editing interaction: %v", err)
 	}
 
+	defaultBatchCount, err := q.defaultBatchCount()
+	if err != nil {
+		log.Printf("Error getting default batch count: %v", err)
+
+		return err
+	}
+
+	defaultBatchSize, err := q.defaultBatchSize()
+	if err != nil {
+		log.Printf("Error getting default batch size: %v", err)
+
+		return err
+	}
+
 	newGeneration.InteractionID = imagine.DiscordInteraction.ID
 	newGeneration.MessageID = message.ID
 	newGeneration.MemberID = imagine.DiscordInteraction.Member.User.ID
 	newGeneration.SortOrder = 0
+	newGeneration.BatchCount = defaultBatchCount
+	newGeneration.BatchSize = defaultBatchSize
+	newGeneration.Processed = true
 
 	_, err = q.imageGenerationRepo.Create(context.Background(), newGeneration)
 	if err != nil {
@@ -498,7 +576,7 @@ func (q *queueImpl) processImagineGrid(newGeneration *entities.ImageGeneration, 
 		SamplerName:       newGeneration.SamplerName,
 		CfgScale:          newGeneration.CfgScale,
 		Steps:             newGeneration.Steps,
-		NIter:             4,
+		NIter:             newGeneration.BatchCount,
 	})
 	if err != nil {
 		log.Printf("Error processing image: %v\n", err)
@@ -546,6 +624,7 @@ func (q *queueImpl) processImagineGrid(newGeneration *entities.ImageGeneration, 
 			HiresWidth:        newGeneration.HiresWidth,
 			HiresHeight:       newGeneration.HiresHeight,
 			DenoisingStrength: newGeneration.DenoisingStrength,
+			BatchCount:        newGeneration.BatchCount,
 			BatchSize:         newGeneration.BatchSize,
 			Seed:              resp.Seeds[idx],
 			Subseed:           resp.Subseeds[idx],
@@ -816,7 +895,7 @@ func (q *queueImpl) processUpscaleImagine(imagine *QueueItem) {
 			HRResizeX:         generation.HiresWidth,
 			HRResizeY:         generation.HiresHeight,
 			DenoisingStrength: generation.DenoisingStrength,
-			BatchSize:         generation.BatchSize,
+			BatchSize:         1,
 			Seed:              generation.Seed,
 			Subseed:           generation.Subseed,
 			SubseedStrength:   generation.SubseedStrength,

--- a/repositories/errors.go
+++ b/repositories/errors.go
@@ -16,9 +16,5 @@ func (m *NotFoundError) Error() string {
 
 func (e *NotFoundError) Is(err error) bool {
 	_, ok := err.(*NotFoundError)
-	if !ok {
-		return false
-	}
-
-	return true
+	return ok
 }

--- a/repositories/image_generations/sqlite.go
+++ b/repositories/image_generations/sqlite.go
@@ -9,15 +9,15 @@ import (
 )
 
 const insertGenerationQuery string = `
-INSERT INTO image_generations (interaction_id, message_id, member_id, sort_order, prompt, negative_prompt, width, height, restore_faces, enable_hr, hires_width, hires_height, denoising_strength, batch_size, seed, subseed, subseed_strength, sampler_name, cfg_scale, steps, processed, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+INSERT INTO image_generations (interaction_id, message_id, member_id, sort_order, prompt, negative_prompt, width, height, restore_faces, enable_hr, hires_width, hires_height, denoising_strength, batch_count, batch_size, seed, subseed, subseed_strength, sampler_name, cfg_scale, steps, processed, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 `
 
 const getGenerationByMessageID string = `
-SELECT id, interaction_id, message_id, member_id, sort_order, prompt, negative_prompt, width, height, restore_faces, enable_hr, hires_width, hires_height, denoising_strength, batch_size, seed, subseed, subseed_strength, sampler_name, cfg_scale, steps, processed, created_at FROM image_generations WHERE message_id = ?;
+SELECT id, interaction_id, message_id, member_id, sort_order, prompt, negative_prompt, width, height, restore_faces, enable_hr, hires_width, hires_height, denoising_strength, batch_count, batch_size, seed, subseed, subseed_strength, sampler_name, cfg_scale, steps, processed, created_at FROM image_generations WHERE message_id = ?;
 `
 
 const getGenerationByMessageIDAndSortOrder string = `
-SELECT id, interaction_id, message_id, member_id, sort_order, prompt, negative_prompt, width, height, restore_faces, enable_hr, hires_width, hires_height, denoising_strength, batch_size, seed, subseed, subseed_strength, sampler_name, cfg_scale, steps, processed, created_at FROM image_generations WHERE message_id = ? AND sort_order = ?;
+SELECT id, interaction_id, message_id, member_id, sort_order, prompt, negative_prompt, width, height, restore_faces, enable_hr, hires_width, hires_height, denoising_strength, batch_count, batch_size, seed, subseed, subseed_strength, sampler_name, cfg_scale, steps, processed, created_at FROM image_generations WHERE message_id = ? AND sort_order = ?;
 `
 
 type sqliteRepo struct {
@@ -49,7 +49,7 @@ func (repo *sqliteRepo) Create(ctx context.Context, generation *entities.ImageGe
 		generation.InteractionID, generation.MessageID, generation.MemberID, generation.SortOrder, generation.Prompt,
 		generation.NegativePrompt, generation.Width, generation.Height, generation.RestoreFaces,
 		generation.EnableHR, generation.HiresWidth, generation.HiresHeight, generation.DenoisingStrength,
-		generation.BatchSize, generation.Seed, generation.Subseed,
+		generation.BatchCount, generation.BatchSize, generation.Seed, generation.Subseed,
 		generation.SubseedStrength, generation.SamplerName, generation.CfgScale, generation.Steps, generation.Processed, generation.CreatedAt)
 	if err != nil {
 		return nil, err
@@ -72,7 +72,7 @@ func (repo *sqliteRepo) GetByMessage(ctx context.Context, messageID string) (*en
 		&generation.ID, &generation.InteractionID, &generation.MessageID, &generation.MemberID, &generation.SortOrder, &generation.Prompt,
 		&generation.NegativePrompt, &generation.Width, &generation.Height, &generation.RestoreFaces,
 		&generation.EnableHR, &generation.HiresWidth, &generation.HiresHeight, &generation.DenoisingStrength,
-		&generation.BatchSize, &generation.Seed, &generation.Subseed,
+		&generation.BatchCount, &generation.BatchSize, &generation.Seed, &generation.Subseed,
 		&generation.SubseedStrength, &generation.SamplerName, &generation.CfgScale, &generation.Steps, &generation.Processed, &generation.CreatedAt)
 	if err != nil {
 		return nil, err
@@ -88,7 +88,7 @@ func (repo *sqliteRepo) GetByMessageAndSort(ctx context.Context, messageID strin
 		&generation.ID, &generation.InteractionID, &generation.MessageID, &generation.MemberID, &generation.SortOrder, &generation.Prompt,
 		&generation.NegativePrompt, &generation.Width, &generation.Height, &generation.RestoreFaces,
 		&generation.EnableHR, &generation.HiresWidth, &generation.HiresHeight, &generation.DenoisingStrength,
-		&generation.BatchSize, &generation.Seed, &generation.Subseed,
+		&generation.BatchCount, &generation.BatchSize, &generation.Seed, &generation.Subseed,
 		&generation.SubseedStrength, &generation.SamplerName, &generation.CfgScale, &generation.Steps, &generation.Processed, &generation.CreatedAt)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This adds a way to configure the balance between batch size and count such that it results in 4 images. Changing the size to 4 sets the count to 1. Setting the size to 2, sets the count to 2, and setting the size to 1 sets the count to 4.

That way, when the request goes through, the API is returning the expected 4 image grid.

Changes:
* Since this is the first PR, added CI lint checks.
* An update was made to the default settings repo, which adds the two new columns. Grid generations also now only get persisted with whatever the batch size/count was at the time of generation.
* The bot values are now used when requesting txt2img from the SD API.
* The discord bot package was also modified to add two new select menus, which calculate the corresponding value for the other setting to balance a result of four images.
* Default bot settings are now read, and then populated with constant default values to fill in added column settings, since these were added as a result of this PR.

The `/imagine_settings` command now presents a message like this, which automatically adjusts the corresponding size/count based on changing the other setting:

<img width="486" alt="Screenshot 2023-01-09 at 9 31 15 PM" src="https://user-images.githubusercontent.com/7525989/211469438-2ddc3415-3d95-4010-bc17-f38f6bd9802c.png">