### PR TITLE
Added imagine_ext command with external parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 stable_diffusion_bot
+stable_diffusion_bot.exe
 .idea/
 sd_discord_bot.sqlite


### PR DESCRIPTION
Added command `imagine_ext` with external options:

- negative prompt
- aspect ratio
- restore faces switch
- CFG scale
- seed

![Discord_2023-03-06_15-09-47](https://user-images.githubusercontent.com/544063/223094245-ebaa54d2-6764-4f00-b4c7-66de06d35516.png)
