### PR TITLE
Prevent crash due to missing (optional) user info in a DM

### DIFF
--- a/discord_bot/discord_bot.go
+++ b/discord_bot/discord_bot.go
@@ -326,13 +326,21 @@ func (b *botImpl) processImagineCommand(s *discordgo.Session, i *discordgo.Inter
 		}
 	}
 
+	userID := ""
+
+	if i.Member != nil {
+		userID = i.Member.User.ID
+	} else if i.User != nil {
+		userID = i.User.ID
+	}
+
 	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
 			Content: fmt.Sprintf(
 				"I'm dreaming something up for you. You are currently #%d in line.\n<@%s> asked me to imagine \"%s\".",
 				position,
-				i.Member.User.ID,
+				userID,
 				prompt),
 		},
 	})

--- a/imagine_queue/queue.go
+++ b/imagine_queue/queue.go
@@ -416,22 +416,32 @@ func (q *queueImpl) getPreviousGeneration(imagine *QueueItem, sortOrder int) (*e
 	return generation, nil
 }
 
-func imagineMessageContent(generation *entities.ImageGeneration, user *discordgo.User, progress float64) string {
+func imagineMessageContent(generation *entities.ImageGeneration, userID string, progress float64) string {
 	if progress >= 0 && progress < 1 {
 		return fmt.Sprintf("<@%s> asked me to imagine \"%s\". Currently dreaming it up for them. Progress: %.0f%%",
-			user.ID, generation.Prompt, progress*100)
+			userID, generation.Prompt, progress*100)
 	} else {
 		return fmt.Sprintf("<@%s> asked me to imagine \"%s\", here is what I imagined for them.",
-			user.ID,
+			userID,
 			generation.Prompt,
 		)
 	}
 }
 
 func (q *queueImpl) processImagineGrid(newGeneration *entities.ImageGeneration, imagine *QueueItem) error {
-	log.Printf("Processing imagine #%s: %v\n", imagine.DiscordInteraction.ID, newGeneration.Prompt)
 
-	newContent := imagineMessageContent(newGeneration, imagine.DiscordInteraction.Member.User, 0)
+	interactionID := imagine.DiscordInteraction.ID
+	userID := ""
+
+	if imagine.DiscordInteraction.Member != nil && imagine.DiscordInteraction.Member.User != nil {
+		userID = imagine.DiscordInteraction.Member.User.ID
+	} else if imagine.DiscordInteraction.User != nil {
+		userID = imagine.DiscordInteraction.User.ID
+	}
+
+	log.Printf("Processing imagine #%s: %v\n", interactionID, newGeneration.Prompt)
+
+	newContent := imagineMessageContent(newGeneration, userID, 0)
 
 	message, err := q.botSession.InteractionResponseEdit(imagine.DiscordInteraction, &discordgo.WebhookEdit{
 		Content: &newContent,
@@ -442,7 +452,7 @@ func (q *queueImpl) processImagineGrid(newGeneration *entities.ImageGeneration, 
 
 	newGeneration.InteractionID = imagine.DiscordInteraction.ID
 	newGeneration.MessageID = message.ID
-	newGeneration.MemberID = imagine.DiscordInteraction.Member.User.ID
+	newGeneration.MemberID = userID
 	newGeneration.SortOrder = 0
 
 	_, err = q.imageGenerationRepo.Create(context.Background(), newGeneration)
@@ -469,7 +479,7 @@ func (q *queueImpl) processImagineGrid(newGeneration *entities.ImageGeneration, 
 					continue
 				}
 
-				progressContent := imagineMessageContent(newGeneration, imagine.DiscordInteraction.Member.User, progress.Progress)
+				progressContent := imagineMessageContent(newGeneration, userID, progress.Progress)
 
 				_, progressErr = q.botSession.InteractionResponseEdit(imagine.DiscordInteraction, &discordgo.WebhookEdit{
 					Content: &progressContent,
@@ -514,7 +524,7 @@ func (q *queueImpl) processImagineGrid(newGeneration *entities.ImageGeneration, 
 
 	generationDone <- true
 
-	finishedContent := imagineMessageContent(newGeneration, imagine.DiscordInteraction.Member.User, 1)
+	finishedContent := imagineMessageContent(newGeneration, userID, 1)
 
 	log.Printf("Seeds: %v Subseeds:%v", resp.Seeds, resp.Subseeds)
 


### PR DESCRIPTION
The code now uses DiscordInteraction.User.ID instead of DiscordInteraction.Member.User.ID when _Member_ is nil.

The bot is no longer crashing interacting over DMs
