### PR TITLE
Fix: 1. Emoji fields in SelectMenuOption and Button structs are optional. 2. Swap height and width variables

### DIFF
--- a/discord_bot/discord_bot.go
+++ b/discord_bot/discord_bot.go
@@ -511,7 +511,7 @@ func (b *botImpl) processImagineSettingsCommand(s *discordgo.Session, i *discord
 	}
 }
 
-func (b *botImpl) processImagineDimensionSetting(s *discordgo.Session, i *discordgo.InteractionCreate, height, width int) {
+func (b *botImpl) processImagineDimensionSetting(s *discordgo.Session, i *discordgo.InteractionCreate, width, height int) {
 	botSettings, err := b.imagineQueue.UpdateDefaultDimensions(width, height)
 	if err != nil {
 		log.Printf("error updating default dimensions: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module stable_diffusion_bot
 go 1.19
 
 require (
-	github.com/bwmarrin/discordgo v0.26.1
+	github.com/bwmarrin/discordgo v0.26.3
 	modernc.org/sqlite v1.20.1
 )
 


### PR DESCRIPTION
Problem: https://github.com/bwmarrin/discordgo/issues/1474

![image](https://github.com/AndBobsYourUncle/stable-diffusion-discord-bot/assets/87629374/4f4345e7-9e5d-48f8-9035-ca80b0421193)

This will render the '/imagine_settings' command unusable.

New release version (v0.26.3) of discordgo has solved the problem.

This pull request just simply changes the version.
